### PR TITLE
Changed LocalLowPath to use UserProfile instead of ApplicationData

### DIFF
--- a/Form1.cs
+++ b/Form1.cs
@@ -21,7 +21,7 @@ namespace EZAudioSwitcher
         [System.Runtime.InteropServices.DllImport("user32.dll")]
         public static extern bool ReleaseCapture();
 
-        public static string LocalLowPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData).Replace("Roaming", "LocalLow");
+        public static string LocalLowPath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile) + "\\AppData\\LocalLow\\";
         public string GameSavePath = LocalLowPath + "\\ZeekerssRBLX\\Lethal Company\\";
         public static string DefaultSaveDirectory = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData) + "\\LCSM\\GameBackups\\";
         public string CustomBackupDirectory = DefaultSaveDirectory;

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.2.0.0")]
+[assembly: AssemblyFileVersion("1.2.0.0")]


### PR DESCRIPTION
This PR addresses an issue where the Lethal Company Save Editor could encounter problems if the Roaming folder is moved to a different location or hard drive. The current implementation relies on replacing "Roaming" in the path obtained from `Environment.SpecialFolder.ApplicationData`, which may not be reliable in all scenarios.

The proposed change updates the `LocalLowPath` to use a more robust and direct approach by using `Environment.SpecialFolder.UserProfile` and appending the necessary path. This ensures that the Save Editor correctly identifies the LocalLow folder regardless of the Roaming folder's location.